### PR TITLE
Improve logging and large file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ python main.py ./pdfs_to_compress -o ./compressed -d 150 -p a4
 | `-o`, `--output` | Output folder for processed PDFs           | `compressed` |
 | `-d`, `--dpi`    | DPI for rendering and compression          | `200`        |
 | `-p`, `--paper`  | Paper size (`a4`, `letter`, `legal`, `a3`) | `a4`         |
+| `-t`, `--timeout`| Ghostscript timeout in seconds             | `600`        |
 
 ---
 


### PR DESCRIPTION
## Summary
- add timeout parameter to `PDFProcessor` and expose via CLI
- document new CLI timeout option
- call `setup_logging` when the app starts

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d032da0e08320a7201ce0c7a4cacc