### PR TITLE
Add unlimited Ghostscript timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ pip install psutil
 ```bash
 python main.py
 ```
+The GUI now includes a field to set the Ghostscript timeout (in seconds).
 
 ### Command Line
 
 ```bash
 python main.py <input_path> [-o OUTPUT] [-d DPI] [-p {a4,letter,legal,a3}] [-t TIMEOUT]
 ```
+`TIMEOUT` controls how long Ghostscript is allowed to run. Set to `0` to disable
+the timeout entirely. The default is `1200` seconds.
 
 For example:
 


### PR DESCRIPTION
## Summary
- allow disabling the timeout by setting it to 0 or less
- update CLI help to mention the new behaviour and display 'no limit' when used
- mention the 0 timeout option in the README

## Testing
- `python -m py_compile main.py`
- `python main.py --help | head -n 20`
- `python main.py --help | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_685d0b62ead08320bc06c67a681f6bf6