### PR TITLE
Update README for large file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ For example:
 python main.py ./pdfs_to_compress -o ./compressed -d 150 -p a4
 ```
 
+### Handling Large Files
+
+Large PDFs may require more time to compress. To avoid interruptions, disable the
+timeout with `-t 0` so Ghostscript can run without a limit. The program will
+automatically move on to the next file if an error occurs.
+
 ### Build an Executable
 
 If you need a standalone executable, install PyInstaller and build:


### PR DESCRIPTION
## Summary
- clarify how to disable the timeout for Ghostscript
- add note that the tool automatically moves to the next file on errors

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685d12d9b8fc8320a6e0b9bdd9737c10